### PR TITLE
Put the yum clean all back in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN yum update -y --security --bugfix && \
                    epel-release \
                    yum-plugin-priorities && \
     yum -y install supervisor cronie && \
+    yum clean all && \
     rm -rf /var/cache/yum/
 
 RUN mkdir -p /etc/osg/image-config.d/


### PR DESCRIPTION
I was wrong about it being redundant when nuking the yum cache.