### PR TITLE
yum update --security does nothing on centos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos7
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
-RUN yum update -y --security --bugfix && \
+RUN yum update -y && \
     yum -y install http://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm \
                    epel-release \
                    yum-plugin-priorities && \


### PR DESCRIPTION
The CentOS repos do not provide the info required to mark packages as security only: [CentOS forums post](https://forums.centos.org/viewtopic.php?t=59369)