### PR TITLE
add github actions workflow to call travis script (SOFTWARE-4171)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -26,6 +26,4 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: opensciencegrid/software-base
-        tags:
-          - fresh
-          - ${{ steps.mkdatetag.outputs.dtag }}
+        tags: fresh,${{ steps.mkdatetag.outputs.dtag }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,7 +2,8 @@ name: build-docker-image
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   schedule:
     - cron: '7 0 * * sun'
 
@@ -10,19 +11,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
+
     steps:
 
     - name: checkout docker-software-base
       uses: actions/checkout@v2
+
+    - name: make date tag
+      id: mkdatetag
+      run: date +%Y%m%d-%H%M
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
       with:
-        path: docker-software-base
-        fetch-depth: 1
-
-    - name: build docker image
-      working-directory: docker-software-base
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      run: ./travis/build_docker.sh
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: opensciencegrid/software-base
+        tags:
+          - fresh
+          - ${{ steps.mkdatetag.outputs.dtag }}
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -11,9 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    outputs:
-      dtag: ${{ steps.mkdatetag.outputs.dtag }}
-
     steps:
 
     - name: checkout docker-software-base
@@ -32,4 +29,3 @@ jobs:
         tags:
           - fresh
           - ${{ steps.mkdatetag.outputs.dtag }}
-

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: make date tag
       id: mkdatetag
-      run: date +%Y%m%d-%H%M
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v1

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,28 @@
+name: build-docker-image
+
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '7 0 * * sun'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: checkout docker-software-base
+      uses: actions/checkout@v2
+      with:
+        path: docker-software-base
+        fetch-depth: 1
+
+    - name: build docker image
+      working-directory: docker-software-base
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      run: ./travis/build_docker.sh
+


### PR DESCRIPTION
Hey @brianhlin,

Can we get away with just calling the current travis script like this?  Or is something else needed?

Does something need to be set up for `secrets.DOCKERHUB_{USERNAME,PASSWORD}` ?
(I saw those [used in docker-xcache](https://github.com/brianhlin/docker-xcache/blob/SOFTWARE-4151.autobuild-xrootd-hotfixes/.github/workflows/hotfix-image-builds.yml#L110-L111).)