### PR TITLE
Build some images explicitly tagged el7-*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ script: ./travis/build_docker.sh
 branches:
   only:
   - master
+  - EL7
   - EL8


### PR DESCRIPTION
The EL7 branch already exists and has this change in it, which caused Travis to push el7-fresh and el7-20200725-0421 tags to dockerhub. Oops.