### PR TITLE
list one repo per line

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -34,7 +34,9 @@ jobs:
     needs: build
     strategy:
       matrix:
-        dispatch-repo: [docker-frontier-squid, docker-xcache]
+        dispatch-repo:
+        - docker-frontier-squid
+        - docker-xcache
     steps:
 
     - name: dispatch build ${{ matrix.dispatch-repo }}


### PR DESCRIPTION
Two repo names fit fine on a single line, but as we add more i think it would be nicer simply to add a single line for a new repo.