### PR TITLE
Add cert update cronjob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ RUN mkdir -p /etc/osg/image-config.d/
 ADD image-config.d/* /etc/osg/image-config.d/
 ADD supervisord_startup.sh /usr/local/sbin/
 ADD supervisord.conf /etc/
+ADD update-certs-rpms-if-present.sh /etc/cron.hourly/
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/update-certs-rpms-if-present.sh
+++ b/update-certs-rpms-if-present.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if rpm -q osg-ca-certs >/dev/null 2>&1; then
+	exec /usr/bin/timeout --kill-after 35m  30m  yum update -y --disablerepo=* --enablerepo=osg osg-ca-certs
+elif rpm -q igtf-ca-certs >/dev/null 2>&1; then
+	exec /usr/bin/timeout --kill-after 35m  30m  yum update -y --disablerepo=* --enablerepo=osg igtf-ca-certs
+fi


### PR DESCRIPTION
This adds a cronjob that updates the CA certs RPMs from the main OSG repo if the certs were installed from the `osg-ca-certs` or `igtf-ca-certs` RPMs.  It does nothing if those RPMs are not installed.

