### PR TITLE
Attempt to complete every build combination

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
     strategy:
+      fail-fast: False
       matrix:
         dver: ['7', '8']
         repo: ['development', 'testing', 'release']


### PR DESCRIPTION
Otherwise a single failure kills the entire workflow. The question is whether or not we should perform the repo dispatch job afterwards:

- I'd be ok with not sending the repo dispatch. If so, this change is helpful for us to determine if build failures are the result of an issue with a specific repo or if it's a larger systemic issue
- If we do send dispatches then downstream builds could fail, or succeed but end up being based on an earlier version of the `software-base` image