### PR TITLE
Add release series to new tags (SOFTWARE-4457)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -38,19 +38,19 @@ jobs:
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
         IMAGE_REPO="${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
-        TAG_PREFIXES=("$SERIES-el$DVER-")
-        TAG_NAMES="$REPO $REPO-$TIMESTAMP"
+        TAG_PREFIXES=("{$SERIES}-el{$DVER}-")
+        TAG_NAMES="${REPO} ${REPO}-${TIMESTAMP}"
         tag_list=''
         for tag_prefix in "${TAG_PREFIXES[@]}"; do
-            for base in $TAG_NAMES; do
-                tag="${IMAGE_REPO}:$tag_prefix$base"
+            for base in ${TAG_NAMES}; do
+                tag="${IMAGE_REPO}:${tag_prefix}${base}"
                 tag_list="${tag_list}${tag_list:+,}${tag}"
             done
         done
         if [[ $DVER == 7 ]] && [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]]; then
             tag_list="${tag_list},$IMAGE_REPO:fresh,$IMAGE_REPO:$TIMESTAMP"
         fi
-        echo "::set-output name=taglist::$tag_list"
+        echo "::set-output name=taglist::${tag_list}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         dver: ['7', '8']
         repo: ['development', 'testing', 'release']
+        series: ['3.5', '3.6']
     needs: make-date-tag
     steps:
     - name: checkout docker-software-base
@@ -33,12 +34,13 @@ jobs:
       env:
         DVER: ${{ matrix.dver }}
         REPO: ${{ matrix.repo }}
+        SERIES: ${{ matrix series }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
-        TAG_PREFIXES=("el$DVER-")
+        TAG_PREFIXES=("$SERIES-el$DVER-")
         TAG_NAMES="$REPO $REPO-$TIMESTAMP"
         [[ $DVER == 7 ]] && TAG_PREFIXES+=('')
-        [[ $REPO == 'testing' ]] && TAG_NAMES="$TAG_NAMES fresh $TIMESTAMP"
+        [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]] && TAG_NAMES="$TAG_NAMES fresh $TIMESTAMP"
         tag_list=''
         for tag_prefix in "${TAG_PREFIXES[@]}"; do
             for base in $TAG_NAMES; do

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -38,18 +38,11 @@ jobs:
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
         IMAGE_REPO="${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
-        TAG_PREFIXES=("{$SERIES}-el{$DVER}-")
-        TAG_NAMES="${REPO} ${REPO}-${TIMESTAMP}"
-        tag_list=''
-        for tag_prefix in "${TAG_PREFIXES[@]}"; do
-            for base in ${TAG_NAMES}; do
-                tag="${IMAGE_REPO}:${tag_prefix}${base}"
-                tag_list="${tag_list}${tag_list:+,}${tag}"
-            done
-        done
-        if [[ $DVER == 7 ]] && [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]]; then
-            tag_list="${tag_list},$IMAGE_REPO:fresh,$IMAGE_REPO:$TIMESTAMP"
+        tags=( $IMAGE_REPO:$SERIES-el$DVER-$REPO{,-$TIMESTAMP} )
+        if [[ $SERIES-el$DVER-$REPO = 3.5-el7-testing ]]; then
+            tags+=( $IMAGE_REPO:{fresh,$TIMESTAMP} )
         fi
+        tag_list=$(IFS=,; echo "${tags[*]}")
         echo "::set-output name=taglist::${tag_list}"
 
     - name: Set up Docker Buildx

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -39,8 +39,10 @@ jobs:
       run: |
         TAG_PREFIXES=("$SERIES-el$DVER-")
         TAG_NAMES="$REPO $REPO-$TIMESTAMP"
-        [[ $DVER == 7 ]] && TAG_PREFIXES+=('')
-        [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]] && TAG_NAMES="$TAG_NAMES fresh $TIMESTAMP"
+        if [[ $DVER == 7 ]] && [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]]; then
+            TAG_PREFIXES+=('')
+            TAG_NAMES="$TAG_NAMES fresh $TIMESTAMP"
+        fi
         tag_list=''
         for tag_prefix in "${TAG_PREFIXES[@]}"; do
             for base in $TAG_NAMES; do

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -37,19 +37,19 @@ jobs:
         SERIES: ${{ matrix series }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
+        IMAGE_REPO="${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
         TAG_PREFIXES=("$SERIES-el$DVER-")
         TAG_NAMES="$REPO $REPO-$TIMESTAMP"
-        if [[ $DVER == 7 ]] && [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]]; then
-            TAG_PREFIXES+=('')
-            TAG_NAMES="$TAG_NAMES fresh $TIMESTAMP"
-        fi
         tag_list=''
         for tag_prefix in "${TAG_PREFIXES[@]}"; do
             for base in $TAG_NAMES; do
-                tag="${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}:$tag_prefix$base"
+                tag="${IMAGE_REPO}:$tag_prefix$base"
                 tag_list="${tag_list}${tag_list:+,}${tag}"
             done
         done
+        if [[ $DVER == 7 ]] && [[ $REPO == 'testing' ]] && [[ $SERIES == '3.5' ]]; then
+            tag_list="${tag_list},$IMAGE_REPO:fresh,$IMAGE_REPO:$TIMESTAMP"
+        fi
         echo "::set-output name=taglist::$tag_list"
 
     - name: Set up Docker Buildx


### PR DESCRIPTION
For the new `development`, `testing`, and `release` tags, this prefixes them with the OSG release series. The intentions are that release-series specific tags will be useful for our own troubleshooting and allow us to transition downstream container images whenever the 3.6 packaging is ready. Additionally, this gets rid of the `development`, `testing`, and `release` tags without series/dver prefixes to avoid confusion. Intended tags to be generated:

```
# 3.5 EL7 testing
fresh
<timestamp>
testing
testing-<timestamp>
3.5-el7-fresh
3.5-el7-<timestamp>
3.5-el7-testing
3.5-el7-testing-<timestamp>

# 3.5 EL8 testing
3.5-el8-testing
3.5-el8-testing-<timestamp>

# 3.6 EL7 testing
3.6-el7-testing
3.6-el7-testing-<timestamp>

# 3.6 EL8 testing
3.6-el8-testing
3.6-el8-testing-<timestamp>

# 3.5 EL7 development
3.5-el7-development
3.5-el7-development-<timestamp>

# 3.5 EL8 development
3.5-el8-development
3.5-el8-development-<timestamp>

# 3.6 EL7 development
3.6-el7-development
3.6-el7-development-<timestamp>

# 3.6 EL8 development
3.6-el8-development
3.6-el8-development-<timestamp>

# 3.5 EL7 release
3.5-el7-release
3.5-el7-release-<timestamp>

# 3.5 EL8 release
3.5-el8-release
3.5-el8-release-<timestamp>

# 3.6 EL7 release
3.6-el7-release
3.6-el7-release-<timestamp>

# 3.6 EL8 release
3.6-el8-release
3.6-el8-release-<timestamp>
```