### PR TITLE
Add cleanup dir (SOFTWARE-4250)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,11 @@ RUN \
         yum-config-manager --enable osg-${BASE_YUM_REPO}; \
     fi && \
     yum clean all && \
-    rm -rf /var/cache/yum/
-
-# Impatiently ignore the Yum mirrors
-RUN sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
-        /etc/yum.repos.d/osg{,-upcoming}-testing.repo
-
-RUN mkdir -p /etc/osg/image-config.d/
-RUN mkdir -p /etc/osg/image-cleanup.d/
+    rm -rf /var/cache/yum/ && \
+    # Impatiently ignore the Yum mirrors
+    sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
+        /etc/yum.repos.d/osg{,-upcoming}-testing.repo && \
+    mkdir -p /etc/osg/image-{cleanup,config}.d/
 
 COPY supervisord_startup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
 
 RUN mkdir -p /etc/osg/image-config.d/
 COPY image-config.d/* /etc/osg/image-config.d/
+
+RUN mkdir -p /etc/osg/image-cleanup.d/
+
 COPY supervisord_startup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ RUN \
     # Impatiently ignore the Yum mirrors
     sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
         /etc/yum.repos.d/osg{,-upcoming}-testing.repo && \
-    mkdir -p /etc/osg/image-{cleanup,config}.d/
+    mkdir -p /etc/osg/image-{cleanup,init}.d/ && \
+    # Support old init script dir name
+    ln -s /etc/osg/image-{init,config}.d
 
 COPY supervisord_startup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ RUN sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
         /etc/yum.repos.d/osg{,-upcoming}-testing.repo
 
 RUN mkdir -p /etc/osg/image-config.d/
-ADD image-config.d/* /etc/osg/image-config.d/
-ADD supervisord_startup.sh /usr/local/sbin/
-ADD supervisord.conf /etc/
-ADD update-certs-rpms-if-present.sh /etc/cron.hourly/
+COPY image-config.d/* /etc/osg/image-config.d/
+COPY supervisord_startup.sh /usr/local/sbin/
+COPY supervisord.conf /etc/
+COPY update-certs-rpms-if-present.sh /etc/cron.hourly/
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
         /etc/yum.repos.d/osg{,-upcoming}-testing.repo
 
 RUN mkdir -p /etc/osg/image-config.d/
-COPY image-config.d/* /etc/osg/image-config.d/
-
 RUN mkdir -p /etc/osg/image-cleanup.d/
 
 COPY supervisord_startup.sh /usr/local/sbin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN \
     rm -rf /var/cache/yum/ && \
     # Impatiently ignore the Yum mirrors
     sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
-        /etc/yum.repos.d/osg{,-upcoming}-testing.repo && \
+        /etc/yum.repos.d/osg*.repo && \
     mkdir -p /etc/osg/image-{cleanup,init}.d/ && \
     # Support old init script dir name
     ln -s /etc/osg/image-{init,config}.d

--- a/image-config.d/20-image-init.sh
+++ b/image-config.d/20-image-init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# this is a dummy init script
-# The descendant image will likely want to replace it with something else

--- a/image-config.d/40-pod-init.sh
+++ b/image-config.d/40-pod-init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# this is a dummy init script
-# The instance of the pod will likely want to replace it with something else

--- a/image-config.d/60-image-post-init.sh
+++ b/image-config.d/60-image-post-init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# this is a dummy init script
-# The descendant image will likely want to replace it with something else

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -3,6 +3,12 @@
 # Allow the derived images to run any additional runtime customizations
 for x in /etc/osg/image-config.d/*.sh; do source "$x"; done
 
+# Allow child images to add cleanup customizations
+function source_cleanup {
+    for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done
+}
+trap source_cleanup EXIT TERM QUIT
+
 # Now we can actually start the supervisor
 exec /usr/bin/supervisord -c /etc/supervisord.conf
 

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Allow the derived images to run any additional runtime customizations
-for x in /etc/osg/image-config.d/*.sh; do source "$x"; done
+for x in /etc/osg/image-init.d/*.sh; do source "$x"; done
 
 # Allow child images to add cleanup customizations
 function source_cleanup {


### PR DESCRIPTION
Analogous to the image init dir, needed by the [`osgvo-docker-pilot`](https://github.com/opensciencegrid/osgvo-docker-pilot/blob/master/entrypoint.sh#L106) so that we can replace the `rm -rf` at the end of `entrypoint.sh`

Also some other misc cleanup:

- Consolidate `RUN` layers for a smaller base image
- Remove unused example init scripts
- Rename init script dir to better differentiate it from the cleanup dir; create a symlink from the old name to the new name to support child images using the old name