### PR TITLE
Disable GHA schedule in favor of k8s cron (SOFTWARE-4617)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: '7 0 * * sun'
   repository_dispatch:
     types: [dispatch-build]
   workflow_dispatch:


### PR DESCRIPTION
The k8s cron triggered successfully yesterday https://github.com/opensciencegrid/docker-software-base/actions/runs/1041972491