### PR TITLE
Fix cron job permissions at build time and run time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,6 @@ COPY supervisord_startup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/
 COPY cron.d/* /etc/cron.d/
-RUN chmod go-w /etc/supervisord.conf /usr/local/sbin/*
+RUN chmod go-w /etc/supervisord.conf /usr/local/sbin/* /etc/cron.*/*
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -9,7 +9,7 @@ function source_cleanup {
 }
 trap source_cleanup EXIT TERM QUIT
 
-chmod go-w /etc/cron.*/*
+chmod go-w /etc/cron.*/* 2>/dev/null || :
 
 # Now we can actually start the supervisor
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
The chmod at runtime can fail (for example if you're not root); ignore the failures so we don't bail out.
