### PR TITLE
rethink container cleanup (SOFTWARE-4762)

### DIFF
--- a/00-cleanup.conf
+++ b/00-cleanup.conf
@@ -1,0 +1,6 @@
+[program:container_cleanup]
+command=/usr/local/sbin/container_cleanup.sh
+priority=-1
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN \
     ln -s /etc/osg/image-{init,config}.d
 
 COPY supervisord_startup.sh /usr/local/sbin/
+COPY container_cleanup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/
+COPY 00-cleanup.conf /etc/supervisord.d/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/
 COPY cron.d/* /etc/cron.d/
 RUN chmod go-w /etc/supervisord.conf /usr/local/sbin/* /etc/cron.*/*

--- a/container_cleanup.sh
+++ b/container_cleanup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Allow child images to add cleanup customizations
+source_cleanup () {
+    for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done
+}
+trap source_cleanup EXIT TERM QUIT
+
+sleep_forever () {
+    /usr/libexec/platform-python -c '__import__("select").select([], [], [])'
+} &> /dev/null
+
+sleep_forever
+

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -3,12 +3,6 @@
 # Allow the derived images to run any additional runtime customizations
 for x in /etc/osg/image-init.d/*.sh; do source "$x"; done
 
-# Allow child images to add cleanup customizations
-function source_cleanup {
-    for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done
-}
-trap source_cleanup EXIT TERM QUIT
-
 chmod go-w /etc/cron.*/* 2>/dev/null || :
 
 # Now we can actually start the supervisor


### PR DESCRIPTION
the trap in supervisord_startup.sh never gets run because supervisord
is started with 'exec', which replaces the bash process.  (So, bash will
no longer be around to run the trap code.)

Two ways came to mind to fix this:

1. remove the 'exec' keyword.

   This seems the simplest, but will result in supervisord being PID 2,
   and the initial supervisord_startup.sh process (bash) will stay PID 1

2. move the trap to a highest-prio supervisord service.

   When supervisord finishes, it will stop this 'service' last, which
   should trigger the cleanup code after everything else.

It was favored in SOFTWARE-4762 to keep supervisord at PID 1, so we've
gone with implementation 2 above.