### PR TITLE
Explicitly run as root to avoid warning message on startup

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,6 +2,7 @@
 nodaemon=true
 logfile=/var/log/supervisord.log
 childlogdir = /var/log/supervisor
+user=root
 
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)


### PR DESCRIPTION
Gets rid of "CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file."
