### PR TITLE
Give fetch-crl a short leash

### DIFF
--- a/cron.d/fetch-crl
+++ b/cron.d/fetch-crl
@@ -1,1 +1,1 @@
-45 */6 * * * root /usr/sbin/fetch-crl -p 5 -r 360 > /var/log/fetch-crl 2>&1
+45 */6 * * * root /usr/sbin/fetch-crl -p 5 -r 360 -T 10 > /var/log/fetch-crl 2>&1


### PR DESCRIPTION
Default timeout is 120 seconds

Am I missing any other aggressive settings @jthiltges ?