### PR TITLE
Replace crond with go-crond

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,10 @@ RUN \
     # Support old init script dir name
     ln -s /etc/osg/image-{init,config}.d
 
-COPY bin/* /usr/local/bin
+RUN GOCROND_VERSION=21.5.0 && curl -s -L -o /usr/local/bin/go-crond \
+       https://github.com/webdevops/go-crond/releases/download/$GOCROND_VERSION/go-crond-64\-linux && \
+    chmod +x /usr/local/bin/go-crond
+COPY bin/* /usr/local/bin/
 COPY supervisord_startup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,6 @@
 nodaemon=true
 logfile=/var/log/supervisord.log
 childlogdir = /var/log/supervisor
-user=root
 
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)
@@ -18,5 +17,5 @@ loglevel=debug
 files=/etc/supervisord.d/*.conf
 
 [program:crond]
-command=/usr/sbin/crond -n
+command=/usr/local/bin/go-crond --allow-unprivileged
 autorestart=true


### PR DESCRIPTION
This replaces crond (which must run as root) with go-crond, which can run as an unprivileged user.