### PR TITLE
explain, for posterity, why not to use the sleep command

### DIFF
--- a/container_cleanup.sh
+++ b/container_cleanup.sh
@@ -7,6 +7,11 @@ source_cleanup () {
 trap source_cleanup EXIT TERM QUIT
 
 sleep_forever () {
+    # NB: this does what it says on the can, unlike "sleep infinity", which
+    #     is not documented in sleep(1) and strace tells me actually does
+    #     a nanosleep of 2073600.999999999s, ie 24d + 1s - 1ns.  Weird, ey?
+    #     Anyway "sleep infinity" is not documented, not portable, and
+    #     doesn't actually sleep forever; so think twice before using it!
     /usr/libexec/platform-python -c '__import__("select").select([], [], [])'
 } &> /dev/null
 


### PR DESCRIPTION
@matyasselmeci asked me, Why not use `sleep infinity` instead?

Since apparently there is some confusion about this topic, even though it's been discussed in chtc-general in the past, perhaps i should leave a comment here to explain the _why not_ for posterity.

...

Well, if you feel that using `select(2)` to pause is _too obscure_ (even though it is a pretty common and portable idiom), we could also use `signal.pause()`, which uses `pause(2)`.  The behavior is effectively the same, i think. (They both pause execution until a signal arrives and (a) kills the process or (b) is handled by a signal handler.)