### PR TITLE
update tag_str to el9 (SOFTWARE-5264)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,7 @@ jobs:
           - image: 'quay.io/almalinux/almalinux:8'
             tag_str: 'al8'
           - image: 'quay.io/almalinux/almalinux:9'
-            tag_str: 'al9'
+            tag_str: 'el9'
           - image: 'nvidia/cuda:11.8.0-runtime-rockylinux8'
             tag_str: 'cuda_11_8_0'
         repo: ['development', 'testing', 'release']


### PR DESCRIPTION
i had done al9 to match the al8 for almalinux:8, but since it's our main one for el9 call it el9