### PR TITLE
enable crb repo for el9 (SOFTWARE-5487)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN \
         yum-config-manager --enable powertools && \
         yum-config-manager --setopt=install_weak_deps=False --save > /dev/null; \
     fi && \
+    if [[ $DVER == 9 ]]; then \
+        yum-config-manager --enable crb && \
+        yum-config-manager --setopt=install_weak_deps=False --save > /dev/null; \
+    fi && \
     if [[ $BASE_YUM_REPO != "release" ]]; then \
         yum-config-manager --enable osg-${BASE_YUM_REPO}; \
         yum-config-manager --enable osg-upcoming-${BASE_YUM_REPO}; else \


### PR DESCRIPTION
since the powertools repo got renamed.

and while we're at it do 'install_weak_deps=False' for el9 also, like we do for el8.  (According to Mat, "it saves space.")