### PR TITLE
Allow running unprivileged, including from Apptainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,7 @@ COPY 00-cleanup.conf /etc/supervisord.d/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/
 COPY cron.d/* /etc/cron.d/
 RUN chmod go-w /etc/supervisord.conf /usr/local/sbin/* /etc/cron.*/*
+# For OKD, which runs as non-root user and root group
+RUN chmod g+w /var/log /var/log/supervisor /var/run
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN \
                    which \
                    less \
                    rpmdevtools \
+                   fakeroot \
                    /usr/bin/ps \
                    && \
     yum clean all && \
@@ -62,6 +63,7 @@ RUN \
 
 COPY bin/* /usr/local/bin/
 COPY supervisord_startup.sh /usr/local/sbin/
+COPY crond_startup.sh /usr/local/sbin/
 COPY container_cleanup.sh /usr/local/sbin/
 COPY supervisord.conf /etc/
 COPY 00-cleanup.conf /etc/supervisord.d/

--- a/crond_startup.sh
+++ b/crond_startup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ $(id -u) != 0 ]; then
+    exec /usr/bin/fakeroot-sysv /usr/sbin/crond -n
+fi
+exec /usr/sbin/crond -n

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+pidfile=/var/run/supervisord.pid
 logfile=/var/log/supervisord.log
 childlogdir = /var/log/supervisor
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,6 @@
 nodaemon=true
 logfile=/var/log/supervisord.log
 childlogdir = /var/log/supervisor
-user=root
 
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)
@@ -18,5 +17,5 @@ loglevel=debug
 files=/etc/supervisord.d/*.conf
 
 [program:crond]
-command=/usr/sbin/crond -n
+command=/usr/local/sbin/crond_startup.sh
 autorestart=true

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -8,5 +8,6 @@ shopt -u nullglob
 chmod go-w /etc/cron.*/* 2>/dev/null || :
 
 # Now we can actually start the supervisor
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+# Use whatever user id this container as run as
+exec /usr/bin/supervisord -c /etc/supervisord.conf -u $(id -u)
 


### PR DESCRIPTION
This PR has changes to the base container that enable running the frontier-squid container (with additional changes I will submit later) as an unprivileged user from Apptainer.