### PR TITLE
Allow enabling/disabling SHA1 cert support via $ENABLE_SHA1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,14 @@ COPY supervisord.conf /etc/
 COPY 00-cleanup.conf /etc/supervisord.d/
 COPY update-certs-rpms-if-present.sh /etc/cron.hourly/
 COPY cron.d/* /etc/cron.d/
+COPY image-init.d/* /etc/osg/image-init.d/
 RUN chmod go-w /etc/supervisord.conf /usr/local/sbin/* /etc/cron.*/*
 # For OKD, which runs as non-root user and root group
 RUN chmod g+w /var/log /var/log/supervisor /var/run
+
+# Allow use of SHA1 certificates.
+# Accepted values are "YES" (enable them, even on EL9), "NO" (disable them, even on EL8), "DEFAULT" (use OS default).
+# No effect on EL7.
+ENV ENABLE_SHA1=DEFAULT
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN \
                    fakeroot \
                    /usr/bin/ps \
                    && \
+    if [[ $DVER == 8 ]]; then \
+        yum -y install crypto-policies-scripts; \
+    fi && \
     yum clean all && \
     rm -rf /var/cache/yum/ && \
     # Impatiently ignore the Yum mirrors

--- a/image-init.d/10-set-crypto-policies.sh
+++ b/image-init.d/10-set-crypto-policies.sh
@@ -29,7 +29,7 @@ if command -v update-crypto-policies &>/dev/null; then
             update-crypto-policies --set DEFAULT >/dev/null
             ;;
     esac
-    echo -n "System crypto policies are:"
+    echo -n "System crypto policies are: "
     update-crypto-policies --show
 fi
 

--- a/image-init.d/10-set-crypto-policies.sh
+++ b/image-init.d/10-set-crypto-policies.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Set system crypto policies based on the ENABLE_SHA1 environment variable.
+if grep -q '^VERSION_ID=["]8' /etc/os-release; then
+    is_el8=true
+else
+    is_el8=false
+fi
+
+if command -v update-crypto-policies &>/dev/null; then
+    # The output of `update-crypto-policies --set` is noisy; silence it
+    # but print the result ourselves.
+    case ${ENABLE_SHA1^^} in
+        YES)
+            if $is_el8; then
+                update-crypto-policies --set DEFAULT >/dev/null
+            else
+                update-crypto-policies --set DEFAULT:SHA1 >/dev/null
+            fi
+            ;;
+        NO)
+            if $is_el8; then
+                update-crypto-policies --set DEFAULT:NO-SHA1 >/dev/null
+            else
+                update-crypto-policies --set DEFAULT >/dev/null
+            fi
+            ;;
+        DEFAULT)
+            update-crypto-policies --set DEFAULT >/dev/null
+            ;;
+    esac
+    echo -n "System crypto policies are:"
+    update-crypto-policies --show
+fi
+


### PR DESCRIPTION
Set ENABLE_SHA1 to YES/NO/DEFAULT to enable/disable/leave at OS default whether SHA1-signed certs are accepted.