### PR TITLE
The almalinux 8 image on quay is broken (missing/bad GPG key) so use the image from dockerhub instead

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -29,7 +29,7 @@ jobs:
             tag_str: 'el7'
           - image: 'quay.io/centos/centos:stream8'
             tag_str: 'el8'
-          - image: 'quay.io/almalinux/almalinux:8'
+          - image: 'docker.io/library/almalinux:8'
             tag_str: 'al8'
           - image: 'quay.io/almalinux/almalinux:9'
             tag_str: 'el9'


### PR DESCRIPTION
(which doesn't (currently) have the same issue)