### PR TITLE
Run crond with `-s` to turn off trying to send mail

### DIFF
--- a/crond_startup.sh
+++ b/crond_startup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ $(id -u) != 0 ]; then
-    exec /usr/bin/fakeroot-sysv /usr/sbin/crond -n
+    exec /usr/bin/fakeroot-sysv /usr/sbin/crond -n -s
 fi
-exec /usr/sbin/crond -n
+exec /usr/sbin/crond -n -s


### PR DESCRIPTION
This keeps the logfile from filling up with messages about crond not being able to send mail or not finding `esmtprc`.