### PR TITLE
Move EL8 image from CentOS Stream 8 to AlmaLinux 8

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -27,10 +27,8 @@ jobs:
         base:
           - image: 'docker.io/centos:centos7'
             tag_str: 'el7'
-          - image: 'quay.io/centos/centos:stream8'
-            tag_str: 'el8'
           - image: 'docker.io/library/almalinux:8'
-            tag_str: 'al8'
+            tag_str: 'el8'
           - image: 'quay.io/almalinux/almalinux:9'
             tag_str: 'el9'
           - image: 'nvidia/cuda:11.8.0-runtime-rockylinux8'


### PR DESCRIPTION
This will effect the following downstream images:

- access-amie
- central-collector
- central-syslog
- frontier-squid
- gwms-factory
- osdf-collector
- osg-pilot-container-probe
- osgstorage-redirector
- ospool-ap
- ospool-ganglia
- ospool-static-registry

Heads up @jthiltges @rynge @lincolnbryant @jdost321 @djw8605 @biozit