### PR TITLE
Remove EL7/3.6 code from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,7 @@ RUN \
     yum makecache && \
     log "Updating OS" && time \
     yum distro-sync -y && \
-    if [[ $OSG_RELEASE =~ ^[0-9][0-9]$ ]]; then \
-       OSG_URL=https://repo.opensciencegrid.org/osg/${OSG_RELEASE}-main/osg-${OSG_RELEASE}-main-el${DVER}-release-latest.rpm; \
-    else \
-       OSG_URL=https://repo.opensciencegrid.org/osg/${OSG_RELEASE}/osg-${OSG_RELEASE}-el${DVER}-release-latest.rpm; \
-    fi && \
+    OSG_URL=https://repo.opensciencegrid.org/osg/${OSG_RELEASE}-main/osg-${OSG_RELEASE}-main-el${DVER}-release-latest.rpm && \
     log "Installing EPEL/OSG repo packages" && time \
     yum -y install $OSG_URL \
                    epel-release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,6 @@ RUN \
     log () { printf "\n%s\t%s\n\n" "$(date '+%F %X %z')" "$*" ; } ; \
     # Attempt to grab the major version from the tag \
     DVER=$(egrep -o '[0-9][\.0-9]*$' <<< "$IMAGE_BASE" | cut -d. -f1); \
-    if  [[ $DVER == 7 ]]; then \
-       YUM_PKG_NAME="yum-plugin-priorities"; \
-       yum-config-manager \
-         --setopt=skip_missing_names_on_install=False \
-         --setopt=skip_missing_names_on_update=False \
-         --save > /dev/null; \
-    else \
-       YUM_PKG_NAME="yum-utils"; \
-    fi && \
     log "Updating OS YUM cache" && time \
     yum makecache && \
     log "Updating OS" && time \
@@ -35,15 +26,9 @@ RUN \
     log "Installing EPEL/OSG repo packages" && time \
     yum -y install $OSG_URL \
                    epel-release \
-                   $YUM_PKG_NAME && \
-    if [[ $DVER == 8 ]]; then \
-        yum-config-manager --enable powertools && \
-        yum-config-manager --setopt=install_weak_deps=False --save > /dev/null; \
-    fi && \
-    if [[ $DVER == 9 ]]; then \
-        yum-config-manager --enable crb && \
-        yum-config-manager --setopt=install_weak_deps=False --save > /dev/null; \
-    fi && \
+                   yum-utils && \
+    yum-config-manager --setopt=install_weak_deps=False --save > /dev/null && \
+    /usr/bin/crb enable && \
     if [[ $BASE_YUM_REPO != "release" ]]; then \
         yum-config-manager --enable osg-${BASE_YUM_REPO}; \
         yum-config-manager --enable osg-upcoming-${BASE_YUM_REPO}; else \
@@ -72,11 +57,6 @@ RUN \
     # Impatiently ignore the Yum mirrors
     sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
         /etc/yum.repos.d/osg*.repo && \
-    # Disable gpgcheck for devops, till we get them rebuilt for SOFTWARE-5422
-    if [[ $OSG_RELEASE == "3.6" ]]; then \
-       sed -i 's/gpgcheck=1/gpgcheck=0/' \
-              /etc/yum.repos.d/devops*.repo; \
-    fi && \
     mkdir -p /etc/osg/image-{cleanup,init}.d/ && \
     # Support old init script dir name
     ln -s /etc/osg/image-{init,config}.d
@@ -96,7 +76,6 @@ RUN chmod g+w /var/log /var/log/supervisor /var/run
 
 # Allow use of SHA1 certificates.
 # Accepted values are "YES" (enable them, even on EL9), "NO" (disable them, even on EL8), "DEFAULT" (use OS default).
-# No effect on EL7.
 ENV ENABLE_SHA1=DEFAULT
 
 CMD ["/usr/local/sbin/supervisord_startup.sh"]


### PR DESCRIPTION
Also makes use of /usr/bin/crb (provided by the epel-release RPM) which enables the powertools/crb repo, as appropriate for the distro.