### PR TITLE
OSPOOL-131: Add arm64 platform to build args

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -77,6 +77,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         build-args: |
           IMAGE_BASE=${{ matrix.base.image }}
           BASE_YUM_REPO=${{ matrix.repo }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -33,6 +33,7 @@ jobs:
             tag_str: 'cuda_11_8_0'
         repo: ['development', 'testing', 'release']
         series: ['23']
+        platform: ['linux/amd64','linux/arm64']
     needs: make-date-tag
     steps:
     - name: checkout docker-software-base
@@ -77,7 +78,7 @@ jobs:
       with:
         context: .
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platform }}
         build-args: |
           IMAGE_BASE=${{ matrix.base.image }}
           BASE_YUM_REPO=${{ matrix.repo }}


### PR DESCRIPTION
Per https://docs.docker.com/build/ci/github-actions/multi-platform/, this should be a default argument to the docker/build-push-action . 

Tested here: https://github.com/opensciencegrid/docker-software-base/actions/runs/11002496912/