### PR TITLE
SOFTWARE-5993: osg-24 software-base

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,7 @@ jobs:
           - image: 'nvidia/cuda:11.8.0-runtime-rockylinux8'
             tag_str: 'cuda_11_8_0'
         repo: ['development', 'testing', 'release']
-        series: ['23']
+        series: ['23', '24']
     needs: make-date-tag
     steps:
     - name: checkout docker-software-base

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'opensciencegrid/')
+    if: startsWith(github.repository, 'opensciencegrid/') || startsWith(github.repository, 'osg-htc/')
     strategy:
       fail-fast: False
       matrix:
@@ -45,10 +45,12 @@ jobs:
         SERIES: ${{ matrix.series }}
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
-        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        image_name=${GITHUB_REPOSITORY/opensciencegrid\/docker-/}
         tags=()
         for registry in hub.opensciencegrid.org docker.io; do
-          tags+=( $registry/$docker_repo:$SERIES-$BASE_STR-$REPO{,-$TIMESTAMP} )
+          for docker_repo in opensciencegrid osg-htc; do
+            tags+=( $registry/$docker_repo/$image_name:$SERIES-$BASE_STR-$REPO{,-$TIMESTAMP} )
+          done
         done
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
@@ -73,7 +75,7 @@ jobs:
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v4
-      continue-on-error: ${{ matrix.repo == 'development' && matrix.series == '23' }}
+      continue-on-error: ${{ matrix.repo == 'development' && (matrix.series == '24')}}
       with:
         context: .
         push: true
@@ -86,7 +88,7 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'opensciencegrid/')
+    if: startsWith(github.repository, 'opensciencegrid/') || startsWith(github.repository, 'osg-htc/')
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -49,6 +49,9 @@ jobs:
         tags=()
         for registry in hub.opensciencegrid.org docker.io; do
           for docker_repo in opensciencegrid osg-htc; do
+            # Don't try to push to docker.io/osg-htc
+            [[ $docker_repo == "osg-htc" && $registry == "docker.io" ]] && continue
+
             tags+=( $registry/$docker_repo/$image_name:$SERIES-$BASE_STR-$REPO{,-$TIMESTAMP} )
           done
         done


### PR DESCRIPTION
- add 24 to series build matrix
- Build into both osg-htc and opensciencegrid, skipping docker.io/osg-htc