### PR TITLE
Fix base AlmaLinux container location

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -27,7 +27,7 @@ jobs:
         base:
           - image: 'docker.io/library/almalinux:8'
             tag_str: 'el8'
-          - image: 'quay.io/almalinuxorg/almalinux:9'
+          - image: 'docker.io/library/almalinux:9'
             tag_str: 'el9'
           - image: 'nvidia/cuda:11.8.0-runtime-rockylinux8'
             tag_str: 'cuda_11_8_0'

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -27,7 +27,7 @@ jobs:
         base:
           - image: 'docker.io/library/almalinux:8'
             tag_str: 'el8'
-          - image: 'quay.io/almalinux/almalinux:9'
+          - image: 'quay.io/almalinuxorg/almalinux:9'
             tag_str: 'el9'
           - image: 'nvidia/cuda:11.8.0-runtime-rockylinux8'
             tag_str: 'cuda_11_8_0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Default to EL9 builds
-ARG IMAGE_BASE=quay.io/almalinux/almalinux:9
+ARG IMAGE_BASE=docker.io/library/almalinux:9
 
 FROM $IMAGE_BASE
 


### PR DESCRIPTION
Per the warning at
<https://wiki.almalinux.org/containers/docker-images.html#about-almalinux-docker-images>, the correct quay.io organization is `almalinuxorg`, not `almalinux`.