### PR TITLE
Don't start container_cleanup if we have no cleanup scripts

### DIFF
--- a/container_cleanup.sh
+++ b/container_cleanup.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [[ -z $(shopt -s nullglob && echo /etc/osg/image-cleanup.d/*.sh) ]]; then
-    exit 0
-fi
-
 # Allow child images to add cleanup customizations
 source_cleanup () {
     for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -7,6 +7,12 @@ shopt -u nullglob
 
 chmod go-w /etc/cron.*/* 2>/dev/null || :
 
+# If we don't have any cleanup scripts, don't start the cleanup service.
+if [[ -z $(shopt -s nullglob && echo /etc/osg/image-cleanup.d/*.sh) ]]; then
+    rm -f /etc/supervisord.d/00-cleanup.conf || :
+fi
+
+
 # Now we can actually start the supervisor
 # Use whatever user id this container as run as
 exec /usr/bin/supervisord -c /etc/supervisord.conf -u $(id -u)


### PR DESCRIPTION
This is better than having container_cleanup exit early because that caused `supervisorctl status` to exit with code 3 instead of 0, which broke the frontier-squid liveness probe.