### PR TITLE
Add OSG 26 builds to software-base, drop 24 builds

### DIFF
--- a/.github/workflows/build-alma10-base.yaml
+++ b/.github/workflows/build-alma10-base.yaml
@@ -1,0 +1,32 @@
+name: build-alma10-base
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # once a week on Sundays at midnight
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: install podman
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman  
+        
+    - name: checkout docker-software-base
+      uses: actions/checkout@v3
+      
+    - name: Log in to OSG Harbor
+      uses: docker/login-action@v2.2.0
+      with:
+        registry: hub.opensciencegrid.org
+        username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+        password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+
+    - name: Build alma10-base image
+      run: |
+        yes no | scripts/create-alma10-base.sh
+
+    - name: Push alma10-base image to OSG Harbor
+      run: |
+        podman manifest push hub.opensciencegrid.org/osg-htc/alma10-base:combo

--- a/.github/workflows/build-alma10-base.yaml
+++ b/.github/workflows/build-alma10-base.yaml
@@ -14,10 +14,10 @@ jobs:
         sudo apt-get install -y podman  
         
     - name: checkout docker-software-base
-      uses: actions/checkout@v3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - name: Log in to OSG Harbor
-      uses: docker/login-action@v2.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: hub.opensciencegrid.org
         username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -35,10 +35,10 @@ jobs:
             # ^^ see scripts/create-alma10-base.sh for how this gets created
             tag_str: 'el10'
         repo: ['development', 'testing', 'release']
-        series: ['24', '25']
+        series: ['25', '26']
         exclude:
-          - series: '24'
-            base: {image: 'hub.opensciencegrid.org/osg-htc/alma10-base:combo', tag_str: 'el10'}
+          - series: '26'
+            repo: 'release' # TODO: OSG 26 is not yet released
     needs: make-date-tag
     steps:
     - name: checkout docker-software-base


### PR DESCRIPTION
Also, add a CronJob to rebuild the alma 10 x86_64_v2 image